### PR TITLE
Fix JS error trying to focus on double-click and also make the focus animation happen instantly

### DIFF
--- a/app/assets/javascripts/todos.coffee
+++ b/app/assets/javascripts/todos.coffee
@@ -12,7 +12,7 @@ $(document).on "blur", ".editing [data-behavior~=submit_on_blur]", ->
 # Thankfully, it's view state, not the actual state of our models
 $(document).on "dblclick", "[data-behavior~=toggle_form_on_dblclick]", ->
   $(@).addClass("editing")
-  $(@).find(".toggle-me").show() ->
+  $(@).find(".toggle-me").show 0, ->
     $(@).find(".edit").focus()
 
 # Note that this is one of two places where "state" is kept in the DOM.

--- a/test/integration/todo_mvc_test.rb
+++ b/test/integration/todo_mvc_test.rb
@@ -128,6 +128,13 @@ class TodoMvcTest < ActionDispatch::IntegrationTest
     assert_items [TODO_ITEM_ONE, "buy some sausages", TODO_ITEM_THREE]
   end
 
+  test "focuses an item on double click" do
+    create_standard_items
+    todo_items[1].double_click
+
+    assert_equal "todo_title", page.evaluate_script('document.activeElement.id')
+  end
+
   test "trim entered text" do
     create_standard_items
     todo_items[1].double_click


### PR DESCRIPTION
I was checking out this project, which is super awesome, and I noticed this feature wasn't quite like the original examples. Plus there was a JS error on double-click to edit. I hope this helps!